### PR TITLE
Fixed #4

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,42 +1,16 @@
-let apiKeyResetTimeout;
-
 chrome.runtime.onInstalled.addListener(() => {
-    chrome.storage.sync.get("geminiApiKey", (data) => {
-        if (!data.geminiApiKey) {
-            chrome.runtime.openOptionsPage();
-        }
-    });
-});
-
-function setupApiKeyReset() {
-    if (apiKeyResetTimeout) {
-        clearTimeout(apiKeyResetTimeout);
+  chrome.storage.sync.get("geminiApiKey", (data) => {
+    if (!data.geminiApiKey) {
+      chrome.runtime.openOptionsPage();
     }
-    
-    const delay = 180000;
-    
-    apiKeyResetTimeout = setTimeout(() => {
-        chrome.storage.sync.remove("geminiApiKey", () => {
-            console.log("API key cleared due to timeout");
-        });
-        
-        setupApiKeyReset();
-    }, delay);
-}
-
-setupApiKeyReset();
-
-chrome.tabs.onActivated.addListener((activeInfo) => {
-    chrome.storage.sync.remove("geminiApiKey", () => {
-        console.log("API key cleared due to tab change");
-    });
+  });
 });
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.action === "saveApiKey") {
-        chrome.storage.sync.set({geminiApiKey: request.apiKey}, () => {
-            sendResponse({success: true, message: "API key saved successfully"});
-        });
-        return true;
-    }
+  if (request.action === "saveApiKey") {
+    chrome.storage.sync.set({ geminiApiKey: request.apiKey }, () => {
+      sendResponse({ success: true, message: "API key saved successfully" });
+    });
+    return true;
+  }
 });

--- a/popup.js
+++ b/popup.js
@@ -116,7 +116,6 @@ const UIManager = {
             this.state.activeListeners.shift();
         }
         
-        chrome.storage.sync.remove("geminiApiKey");
     }
 };
 


### PR DESCRIPTION
Fixed the bug where the API key was not being saved consistently. 

There were two problems in the code. The deletion was triggered by two events:
1. on every tab change (chrome.tabs.onActivated)
2. on a recurring 3-minute timer (setTimeout in the setupApiKeyReset function).

I fixed it by removing the two functions responsible for the deletion of the API key.
chrome.tabs.onActivated listener and the setupApiKeyReset timeout function has been removed.

I have tested it the code after fixing it and the issue has been resolved.

Also, i removed the following line from popup.js which was deleting the key when popup window was closing.
chrome.storage.sync.remove("geminiApiKey");